### PR TITLE
Redirect on uauth feature

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -34,6 +34,7 @@ type SignatureConfig struct {
 	RefreshBodyProperty string  `json:"refresh_property"`
 	RefreshCookieKey   string   `json:"refresh_cookie_key"`
 	RefreshCookieDomain string  `json:"refresh_cookie_domain"`
+	RedirectOnUnauthorizedTo string `json:"redirect_on_unauth_to"`
 }
 
 type SignerConfig struct {


### PR DESCRIPTION
@openrm/dev add feature to be able to configure the redirect url in case the jwt token is expired/invalid 

After merging this will require a krakend-ce update